### PR TITLE
b2qt.xml: meta-boot2qt: lock upstream to "scarthgap" and revision to "#7cfdf20"

### DIFF
--- a/b2qt.xml
+++ b/b2qt.xml
@@ -6,7 +6,7 @@
 
   <remove-project name="meta-qt6"/>
 
-  <project name="meta-boot2qt" path="sources/meta-boot2qt" remote="qt6" revision="scarthgap"/>
+  <project name="meta-boot2qt" path="sources/meta-boot2qt" remote="qt6" revision="7cfdf20adf6a33eb5b9b3a210b2d6dadde22b958" upstream="scarthgap"/>
   <project name="meta-mingw" path="sources/meta-mingw" remote="yp" revision="refs/tags/yocto-5.0.4"/>
   <project name="meta-qt6" path="sources/meta-qt6" remote="qt6" revision="refs/tags/v6.8.1"/>
 </manifest>


### PR DESCRIPTION
This PR works around a build issue introduced by commit [#ef3a7dc0](https://code.qt.io/cgit/yocto/meta-boot2qt.git/commit/?h=scarthgap&id=ef3a7dc0f9125563eae08af4237eb8011e829267) in `meta-boot2qt` by locking `b2qt.xml` to the previous commit [#7cfdf20a](https://code.qt.io/cgit/yocto/meta-boot2qt.git/commit/?h=scarthgap&id=7cfdf20adf6a33eb5b9b3a210b2d6dadde22b958). _Note_: This is a temporary solution until all layers are updated accordingly. The changes have been verified with the instructions provided at https://lairdcp.github.io/guides/Boot2Qt-Scarthgap-Release-for-iMX-Platforms/1.0/Boot2Qt-Scarthgap-Release-for-i.MX-Platforms.html, a full clean local build using our Ubuntu 20.04 Docker container (`dockerfile_focal`) for reproducible Yocto builds, and manually confirmed via: `bitbake ezurio-meta-b2qt-embedded-qbsp -c fetch boot2qt-demolauncher -f`.